### PR TITLE
feat(admin-panel): Enhance forms with DND and new sections

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config=jest.config.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@heroicons/react": "^2.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/src/components/OrganizationProfileForm.tsx
+++ b/src/components/OrganizationProfileForm.tsx
@@ -1,11 +1,29 @@
-import React, { useState, useEffect, useCallback, memo } from 'react';
-import { OrganizationProfileData, AddressItem, ContactItem, SocialMediaLink, OrganizationMember } from '@/types/supabase';
+import React, { useState, useEffect, memo, useMemo } from 'react';
+import { OrganizationProfileData, AddressItem, ContactItem, SocialMediaLink, OrganizationMember, PartnershipItem } from '@/types/supabase';
+import { uploadPartnerLogo } from '@/lib/supabase';
 import { v4 as uuidv4 } from 'uuid';
 import dynamic from 'next/dynamic';
+import Image from 'next/image';
 import * as Form from '@radix-ui/react-form';
 import * as Label from '@radix-ui/react-label';
 import * as Tooltip from '@radix-ui/react-tooltip';
-import { PlusIcon, TrashIcon, MapPinIcon, GlobeAltIcon, PhoneIcon, UsersIcon, BuildingOfficeIcon, EyeIcon as VisionIcon } from '@heroicons/react/24/outline';
+import * as Progress from '@radix-ui/react-progress';
+import { PlusIcon, TrashIcon, MapPinIcon, GlobeAltIcon, PhoneIcon, UsersIcon, BuildingOfficeIcon, EyeIcon, Bars2Icon, PhotoIcon, BriefcaseIcon, AcademicCapIcon } from '@heroicons/react/24/outline';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 const MapPicker = dynamic(() => import('./MapPicker'), {
   ssr: false,
@@ -15,13 +33,14 @@ const MapPicker = dynamic(() => import('./MapPicker'), {
 const getInitialFormData = (data?: OrganizationProfileData | null): OrganizationProfileData => ({
   id: data?.id,
   slogan: data?.slogan || '',
-  addresses: data?.addresses || [],
-  phone_numbers: data?.phone_numbers || [],
+  addresses: data?.addresses?.map(item => ({ ...item, id: item.id || uuidv4() })) || [],
+  phone_numbers: data?.phone_numbers?.map(item => ({ ...item, id: item.id || uuidv4() })) || [],
   email: data?.email || '',
-  social_media_links: data?.social_media_links || [],
+  social_media_links: data?.social_media_links?.map(item => ({ ...item, id: item.id || uuidv4() })) || [],
   vision: data?.vision || '',
   mission: data?.mission || '',
-  organizational_structure: data?.organizational_structure || [],
+  organizational_structure: data?.organizational_structure?.map(item => ({ ...item, id: item.id || uuidv4() })) || [],
+  partnerships: data?.partnerships?.map(item => ({ ...item, id: item.id || uuidv4() })) || [],
 });
 
 const Section: React.FC<{ title: string; icon: React.ElementType; children: React.ReactNode }> = ({ title, icon: Icon, children }) => (
@@ -34,328 +53,265 @@ const Section: React.FC<{ title: string; icon: React.ElementType; children: Reac
   </div>
 );
 
-const ArrayItemWrapper: React.FC<{ onRemove: () => void; children: React.ReactNode; removeTooltip: string }> = ({ onRemove, children, removeTooltip }) => (
-  <div className="p-4 bg-gray-700/40 rounded-lg border border-gray-600/50 relative">
-    {children}
-    <Tooltip.Root>
-      <Tooltip.Trigger asChild>
-        <button
-          type="button"
-          onClick={onRemove}
-          className="absolute top-3 right-3 p-1.5 text-red-400 hover:text-red-300 hover:bg-red-500/20 rounded-md transition-colors"
-        >
-          <TrashIcon className="w-5 h-5" />
-        </button>
-      </Tooltip.Trigger>
-      <Tooltip.Portal>
-        <Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700" sideOffset={5}>
-          {removeTooltip}
-          <Tooltip.Arrow className="fill-gray-900" />
-        </Tooltip.Content>
-      </Tooltip.Portal>
-    </Tooltip.Root>
-  </div>
-);
+const SortableItemWrapper: React.FC<{ id: string, children: React.ReactNode }> = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id });
 
-type ItemUpdateHandler<T extends { id: string }> = <K extends keyof T>(id: string, field: K, value: T[K]) => void;
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.7 : 1,
+    zIndex: isDragging ? 100 : 'auto'
+  };
 
-interface AddressItemFormProps {
-  item: AddressItem;
-  index: number;
-  onUpdate: ItemUpdateHandler<AddressItem>;
-  onPositionChange: (id: string, lat: number, lng: number) => void;
-  onRemove: () => void;
-}
-
-const AddressItemForm = memo<AddressItemFormProps>(({ item, index, onUpdate, onPositionChange, onRemove }) => (
-  <ArrayItemWrapper onRemove={onRemove} removeTooltip="Hapus Alamat">
-    <div className="space-y-3">
-      <Form.Field name={`address_text_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Baris Alamat {index + 1}</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="text" value={item.text} onChange={e => onUpdate(item.id, 'text', e.target.value)} className="input-field-sm" placeholder="Alamat Lengkap" />
-        </Form.Control>
-      </Form.Field>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Form.Field name={`address_lat_${item.id}`}>
-          <Form.Label asChild><Label.Root className="input-label-sm">Lintang</Label.Root></Form.Label>
-          <Form.Control asChild>
-            <input type="number" step="any" value={item.latitude ?? ''} onChange={e => onUpdate(item.id, 'latitude', parseFloat(e.target.value) || null)} className="input-field-sm" placeholder="cth., -7.7956" />
-          </Form.Control>
-        </Form.Field>
-        <Form.Field name={`address_lon_${item.id}`}>
-          <Form.Label asChild><Label.Root className="input-label-sm">Bujur</Label.Root></Form.Label>
-          <Form.Control asChild>
-            <input type="number" step="any" value={item.longitude ?? ''} onChange={e => onUpdate(item.id, 'longitude', parseFloat(e.target.value) || null)} className="input-field-sm" placeholder="cth., 110.3695" />
-          </Form.Control>
-        </Form.Field>
-      </div>
-      <MapPicker
-        initialPosition={item.latitude && item.longitude ? [item.latitude, item.longitude] : null}
-        onPositionChange={(lat, lng) => onPositionChange(item.id, lat, lng)}
-      />
-      <Form.Field name={`address_notes_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Catatan (Opsional)</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="text" value={item.notes || ''} onChange={e => onUpdate(item.id, 'notes', e.target.value)} className="input-field-sm" placeholder="cth., Kantor Pusat, Kantor Cabang" />
-        </Form.Control>
-      </Form.Field>
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-start gap-3 bg-gray-700/40 rounded-lg border border-gray-600/50 relative p-4">
+      <Tooltip.Root><Tooltip.Trigger asChild><button type="button" {...attributes} {...listeners} className="p-1.5 cursor-grab text-gray-400 hover:text-white hover:bg-gray-600/50 rounded-md mt-2"><Bars2Icon className="w-5 h-5" /></button></Tooltip.Trigger><Tooltip.Portal><Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700 z-[101]" sideOffset={5}>Geser untuk Mengurutkan<Tooltip.Arrow className="fill-gray-900" /></Tooltip.Content></Tooltip.Portal></Tooltip.Root>
+      <div className="flex-grow">{children}</div>
     </div>
-  </ArrayItemWrapper>
+  );
+};
+
+const SortableSection = <T extends { id: string }>({
+  items,
+  onReorder,
+  renderItem,
+}: {
+  items: T[];
+  onReorder: (reorderedItems: T[]) => void;
+  renderItem: (item: T, index: number) => React.ReactNode;
+}) => {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 10 } }));
+  const itemIds = useMemo(() => items.map(i => i.id), [items]);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = items.findIndex(item => item.id === active.id);
+      const newIndex = items.findIndex(item => item.id === over.id);
+      onReorder(arrayMove(items, oldIndex, newIndex));
+    }
+  };
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+        <div className="space-y-3">
+          {items.map((item, index) => (
+            <SortableItemWrapper key={item.id} id={item.id}>
+              {renderItem(item, index)}
+            </SortableItemWrapper>
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+};
+
+type ItemUpdateHandler<T> = <K extends keyof T>(id: string, field: K, value: T[K]) => void;
+
+const AddressItemForm = memo<{ item: AddressItem; index: number; onUpdate: ItemUpdateHandler<AddressItem>; onPositionChange: (id: string, lat: number, lng: number) => void; onRemove: (id: string) => void }>(({ item, index, onUpdate, onPositionChange, onRemove }) => (
+  <div className="w-full space-y-3">
+    <div className="flex justify-between items-center"><Label.Root className="input-label-sm !mb-0 text-base">Alamat {index + 1}</Label.Root><Tooltip.Root><Tooltip.Trigger asChild><button type="button" onClick={() => onRemove(item.id)} className="p-1.5 text-red-400 hover:text-red-300 hover:bg-red-500/20 rounded-md transition-colors"><TrashIcon className="w-5 h-5" /></button></Tooltip.Trigger><Tooltip.Portal><Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700 z-[101]" sideOffset={5}>Hapus Alamat<Tooltip.Arrow className="fill-gray-900" /></Tooltip.Content></Tooltip.Portal></Tooltip.Root></div>
+    <Form.Field name={`address_text_${item.id}`}><Form.Control asChild><input type="text" value={item.text} onChange={e => onUpdate(item.id, 'text', e.target.value)} className="input-field-sm" placeholder="Alamat Lengkap" /></Form.Control></Form.Field>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3"><Form.Field name={`address_lat_${item.id}`}><Form.Label asChild><Label.Root className="input-label-sm">Lintang</Label.Root></Form.Label><Form.Control asChild><input type="number" step="any" value={item.latitude ?? ''} onChange={e => onUpdate(item.id, 'latitude', parseFloat(e.target.value) || null)} className="input-field-sm" placeholder="cth., -7.7956" /></Form.Control></Form.Field><Form.Field name={`address_lon_${item.id}`}><Form.Label asChild><Label.Root className="input-label-sm">Bujur</Label.Root></Form.Label><Form.Control asChild><input type="number" step="any" value={item.longitude ?? ''} onChange={e => onUpdate(item.id, 'longitude', parseFloat(e.target.value) || null)} className="input-field-sm" placeholder="cth., 110.3695" /></Form.Control></Form.Field></div>
+    <MapPicker initialPosition={item.latitude && item.longitude ? [item.latitude, item.longitude] : null} onPositionChange={(lat, lng) => onPositionChange(item.id, lat, lng)} /><Form.Field name={`address_notes_${item.id}`}><Form.Label asChild><Label.Root className="input-label-sm">Catatan (Opsional)</Label.Root></Form.Label><Form.Control asChild><input type="text" value={item.notes || ''} onChange={e => onUpdate(item.id, 'notes', e.target.value)} className="input-field-sm" placeholder="cth., Kantor Pusat" /></Form.Control></Form.Field>
+  </div>
 ));
 AddressItemForm.displayName = 'AddressItemForm';
 
-interface ContactItemFormProps {
-  item: ContactItem;
-  index: number;
-  onUpdate: ItemUpdateHandler<ContactItem>;
-  onRemove: () => void;
-}
-
-const ContactItemForm = memo<ContactItemFormProps>(({ item, index, onUpdate, onRemove }) => (
-  <ArrayItemWrapper onRemove={onRemove} removeTooltip='Hapus Nomor Telepon'>
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-      <Form.Field name={`phone_number_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Nomor Telepon {index + 1}</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="tel" value={item.number} onChange={e => onUpdate(item.id, 'number', e.target.value)} className="input-field-sm" placeholder="+62 123 4567 890" />
-        </Form.Control>
-      </Form.Field>
-      <Form.Field name={`phone_label_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Label (Opsional)</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="text" value={item.label || ''} onChange={e => onUpdate(item.id, 'label', e.target.value)} className="input-field-sm" placeholder="cth., Kantor, WhatsApp" />
-        </Form.Control>
-      </Form.Field>
+const ContactItemForm = memo<{ item: ContactItem; onUpdate: ItemUpdateHandler<ContactItem>; onRemove: (id: string) => void }>(({ item, onUpdate, onRemove }) => (
+    <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-3 items-end">
+        <Form.Field name={`phone_number_${item.id}`} className="flex-grow"><Form.Label asChild><Label.Root className="input-label-sm">Nomor Telepon</Label.Root></Form.Label><Form.Control asChild><input type="tel" value={item.number} onChange={e => onUpdate(item.id, 'number', e.target.value)} className="input-field-sm" placeholder="+62 123 4567 890" /></Form.Control></Form.Field>
+        <div className="flex items-end gap-3"><Form.Field name={`phone_label_${item.id}`} className="flex-grow"><Form.Label asChild><Label.Root className="input-label-sm">Label</Label.Root></Form.Label><Form.Control asChild><input type="text" value={item.label || ''} onChange={e => onUpdate(item.id, 'label', e.target.value)} className="input-field-sm" placeholder="cth., Kantor" /></Form.Control></Form.Field><Tooltip.Root><Tooltip.Trigger asChild><button type="button" onClick={() => onRemove(item.id)} className="p-2 text-red-400 hover:text-red-300 hover:bg-red-500/20 rounded-md transition-colors mb-px"><TrashIcon className="w-5 h-5" /></button></Tooltip.Trigger><Tooltip.Portal><Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700 z-[101]" sideOffset={5}>Hapus Nomor<Tooltip.Arrow className="fill-gray-900" /></Tooltip.Content></Tooltip.Portal></Tooltip.Root></div>
     </div>
-  </ArrayItemWrapper>
 ));
 ContactItemForm.displayName = 'ContactItemForm';
 
-interface SocialMediaItemFormProps {
-  item: SocialMediaLink;
-  index: number;
-  onUpdate: ItemUpdateHandler<SocialMediaLink>;
-  onRemove: () => void;
-}
-
-const SocialMediaItemForm = memo<SocialMediaItemFormProps>(({ item, index, onUpdate, onRemove }) => (
-  <ArrayItemWrapper onRemove={onRemove} removeTooltip='Hapus Tautan Sosial'>
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-      <Form.Field name={`social_platform_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Platform {index + 1}</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="text" value={item.platform} onChange={e => onUpdate(item.id, 'platform', e.target.value)} className="input-field-sm" placeholder="cth., Instagram, Situs Web" />
-        </Form.Control>
-      </Form.Field>
-      <Form.Field name={`social_url_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">URL</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="url" value={item.url} onChange={e => onUpdate(item.id, 'url', e.target.value)} className="input-field-sm" placeholder="https://..." />
-        </Form.Control>
-      </Form.Field>
+const SocialMediaItemForm = memo<{ item: SocialMediaLink; onUpdate: ItemUpdateHandler<SocialMediaLink>; onRemove: (id: string) => void }>(({ item, onUpdate, onRemove }) => (
+    <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-3 items-end">
+      <Form.Field name={`social_platform_${item.id}`} className="flex-grow"><Form.Label asChild><Label.Root className="input-label-sm">Platform</Label.Root></Form.Label><Form.Control asChild><input type="text" value={item.platform} onChange={e => onUpdate(item.id, 'platform', e.target.value)} className="input-field-sm" placeholder="cth., Instagram" /></Form.Control></Form.Field>
+       <div className="flex items-end gap-3"><Form.Field name={`social_url_${item.id}`} className="flex-grow"><Form.Label asChild><Label.Root className="input-label-sm">URL</Label.Root></Form.Label><Form.Control asChild><input type="url" value={item.url} onChange={e => onUpdate(item.id, 'url', e.target.value)} className="input-field-sm" placeholder="https://..." /></Form.Control></Form.Field><Tooltip.Root><Tooltip.Trigger asChild><button type="button" onClick={() => onRemove(item.id)} className="p-2 text-red-400 hover:text-red-300 hover:bg-red-500/20 rounded-md transition-colors mb-px"><TrashIcon className="w-5 h-5" /></button></Tooltip.Trigger><Tooltip.Portal><Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700 z-[101]" sideOffset={5}>Hapus Tautan<Tooltip.Arrow className="fill-gray-900" /></Tooltip.Content></Tooltip.Portal></Tooltip.Root></div>
     </div>
-  </ArrayItemWrapper>
 ));
 SocialMediaItemForm.displayName = 'SocialMediaItemForm';
 
-interface OrganizationMemberFormProps {
-  item: OrganizationMember;
-  index: number;
-  onUpdate: ItemUpdateHandler<OrganizationMember>;
-  onRemove: () => void;
-}
-
-const OrganizationMemberForm = memo<OrganizationMemberFormProps>(({ item, index, onUpdate, onRemove }) => (
-  <ArrayItemWrapper onRemove={onRemove} removeTooltip='Hapus Anggota'>
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-      <Form.Field name={`org_position_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Posisi {index + 1}</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="text" value={item.position} onChange={e => onUpdate(item.id, 'position', e.target.value)} className="input-field-sm" placeholder="cth., Direktur" />
-        </Form.Control>
-      </Form.Field>
-      <Form.Field name={`org_name_${item.id}`}>
-        <Form.Label asChild><Label.Root className="input-label-sm">Nama</Label.Root></Form.Label>
-        <Form.Control asChild>
-          <input type="text" value={item.name} onChange={e => onUpdate(item.id, 'name', e.target.value)} className="input-field-sm" placeholder="Nama Lengkap" />
-        </Form.Control>
-      </Form.Field>
+const OrganizationMemberForm = memo<{ item: OrganizationMember; onUpdate: ItemUpdateHandler<OrganizationMember>; onRemove: (id: string) => void }>(({ item, onUpdate, onRemove }) => (
+    <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-3 items-end">
+      <Form.Field name={`org_position_${item.id}`} className="flex-grow"><Form.Label asChild><Label.Root className="input-label-sm">Posisi</Label.Root></Form.Label><Form.Control asChild><input type="text" value={item.position} onChange={e => onUpdate(item.id, 'position', e.target.value)} className="input-field-sm" placeholder="cth., Direktur" /></Form.Control></Form.Field>
+       <div className="flex items-end gap-3"><Form.Field name={`org_name_${item.id}`} className="flex-grow"><Form.Label asChild><Label.Root className="input-label-sm">Nama</Label.Root></Form.Label><Form.Control asChild><input type="text" value={item.name} onChange={e => onUpdate(item.id, 'name', e.target.value)} className="input-field-sm" placeholder="Nama Lengkap" /></Form.Control></Form.Field><Tooltip.Root><Tooltip.Trigger asChild><button type="button" onClick={() => onRemove(item.id)} className="p-2 text-red-400 hover:text-red-300 hover:bg-red-500/20 rounded-md transition-colors mb-px"><TrashIcon className="w-5 h-5" /></button></Tooltip.Trigger><Tooltip.Portal><Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700 z-[101]" sideOffset={5}>Hapus Anggota<Tooltip.Arrow className="fill-gray-900" /></Tooltip.Content></Tooltip.Portal></Tooltip.Root></div>
     </div>
-  </ArrayItemWrapper>
 ));
 OrganizationMemberForm.displayName = 'OrganizationMemberForm';
 
-interface OrganizationProfileFormProps {
-  initialData: OrganizationProfileData | null;
-  onSave: (data: OrganizationProfileData) => Promise<void>;
-  isSaving: boolean;
-}
+const PartnershipItemForm = memo<{ item: PartnershipItem; onUpdate: ItemUpdateHandler<PartnershipItem>; onRemove: (id: string) => void }>(({ item, onUpdate, onRemove }) => {
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
 
-const OrganizationProfileForm: React.FC<OrganizationProfileFormProps> = ({ initialData, onSave, isSaving }) => {
-  const [formData, setFormData] = useState<OrganizationProfileData>(() => getInitialFormData(initialData));
-
-  useEffect(() => {
-    setFormData(getInitialFormData(initialData));
-  }, [initialData]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+  const handleLogoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files || e.target.files.length === 0) return;
+    const file = e.target.files[0];
+    setIsUploading(true);
+    setUploadProgress(10);
+    try {
+      const url = await uploadPartnerLogo(file);
+      setUploadProgress(100);
+      onUpdate(item.id, 'logo_url', url);
+    } catch (error) {
+      console.error("Logo upload failed", error);
+      alert('Gagal mengunggah logo.');
+    } finally {
+      setIsUploading(false);
+      setUploadProgress(0);
+    }
   };
 
-  const handleArrayChange = useCallback(<TItem extends { id: string }, TField extends keyof TItem>(
-    arrayName: keyof OrganizationProfileData,
-    itemId: string,
-    field: TField,
-    value: TItem[TField]
-  ) => {
-    setFormData(prev => {
-        const oldArray = prev[arrayName] as unknown as TItem[];
-        const newArray = oldArray.map(item =>
-            item.id === itemId ? { ...item, [field]: value } : item
-        );
-        return { ...prev, [arrayName]: newArray };
-    });
-  }, []);
+  return (
+    <div className="w-full flex items-start gap-4">
+      <div className="flex-shrink-0 space-y-2">
+        <div className="w-20 h-20 bg-gray-600/50 rounded-lg flex items-center justify-center border border-gray-500/50 overflow-hidden relative">
+          {item.logo_url ? <Image src={item.logo_url} alt={item.name} fill className="object-contain" /> : <PhotoIcon className="w-8 h-8 text-gray-400" />}
+        </div>
+        <input type="file" id={`logo-upload-${item.id}`} accept="image/*" onChange={handleLogoUpload} className="hidden" disabled={isUploading} />
+        <label htmlFor={`logo-upload-${item.id}`} className="w-full text-xs text-center cursor-pointer secondary-button-sm flex items-center justify-center gap-1.5"><PhotoIcon className="w-3 h-3" /> Ganti Logo</label>
+        {isUploading && <Progress.Root value={uploadProgress} className="relative overflow-hidden bg-gray-800 rounded-full w-full h-1"><Progress.Indicator className="bg-red-500 h-full transition-transform duration-300" style={{ transform: `translateX(-${100 - uploadProgress}%)` }} /></Progress.Root>}
+      </div>
+      <div className="flex-grow space-y-3">
+        <Form.Field name={`partner_name_${item.id}`}><Form.Label asChild><Label.Root className="input-label-sm">Nama Mitra</Label.Root></Form.Label><Form.Control asChild><input type="text" value={item.name} onChange={e => onUpdate(item.id, 'name', e.target.value)} className="input-field-sm" placeholder="Nama Institusi/Perusahaan" /></Form.Control></Form.Field>
+      </div>
+      <Tooltip.Root><Tooltip.Trigger asChild><button type="button" onClick={() => onRemove(item.id)} className="p-1.5 text-red-400 hover:text-red-300 hover:bg-red-500/20 rounded-md transition-colors mt-2"><TrashIcon className="w-5 h-5" /></button></Tooltip.Trigger><Tooltip.Portal><Tooltip.Content className="bg-gray-900 text-white px-2 py-1 rounded text-sm shadow-lg border border-gray-700 z-[101]" sideOffset={5}>Hapus Mitra<Tooltip.Arrow className="fill-gray-900" /></Tooltip.Content></Tooltip.Portal></Tooltip.Root>
+    </div>
+  );
+});
+PartnershipItemForm.displayName = 'PartnershipItemForm';
 
-  const addArrayItem = useCallback(<T extends { id: string }>(arrayName: keyof OrganizationProfileData, newItem: Omit<T, 'id'>) => {
-    setFormData(prev => ({
-      ...prev,
-      [arrayName]: [...(prev[arrayName] as unknown as T[]), { ...newItem, id: uuidv4() } as T],
-    }));
-  }, []);
 
-  const removeArrayItem = useCallback((arrayName: keyof OrganizationProfileData, itemId: string) => {
-    setFormData(prev => ({
-      ...prev,
-      [arrayName]: (prev[arrayName] as unknown as Array<{id: string}>).filter(item => item.id !== itemId),
-    }));
-  }, []);
+const OrganizationProfileForm: React.FC<{ initialData: OrganizationProfileData | null; onSave: (data: OrganizationProfileData) => Promise<void>; isSaving: boolean; }> = ({ initialData, onSave, isSaving }) => {
+  const [formData, setFormData] = useState<OrganizationProfileData>(() => getInitialFormData(initialData));
 
-  const handleAddressPositionChange = useCallback((addressId: string, lat: number, lng: number) => {
-    setFormData(prev => ({
-      ...prev,
-      addresses: prev.addresses.map(addr =>
-        addr.id === addressId ? { ...addr, latitude: lat, longitude: lng } : addr
-      ),
-    }));
-  }, []);
+  useEffect(() => { setFormData(getInitialFormData(initialData)); }, [initialData]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     await onSave(formData);
   };
 
+  const { educationPartners, industryPartners } = useMemo(() => {
+    const educationPartners = formData.partnerships.filter(p => p.category === 'education_government');
+    const industryPartners = formData.partnerships.filter(p => p.category === 'industry');
+    return { educationPartners, industryPartners };
+  }, [formData.partnerships]);
+
   return (
-    <Tooltip.Provider>
+    <Tooltip.Provider delayDuration={100}>
       <Form.Root onSubmit={handleSubmit} className="space-y-8">
         <Section title="Informasi Umum" icon={BuildingOfficeIcon}>
-          <Form.Field name="slogan" className="space-y-2">
-            <Form.Label asChild><Label.Root className="block text-sm font-medium text-gray-300">Slogan</Label.Root></Form.Label>
-            <Form.Control asChild>
-              <input type="text" name="slogan" value={formData.slogan || ''} onChange={handleChange} className="input-field" placeholder="Slogan Perusahaan" />
-            </Form.Control>
-          </Form.Field>
-          <Form.Field name="email" className="space-y-2">
-            <Form.Label asChild><Label.Root className="block text-sm font-medium text-gray-300">Email</Label.Root></Form.Label>
-            <Form.Control asChild>
-              <input type="email" name="email" value={formData.email || ''} onChange={handleChange} className="input-field" placeholder="kontak@contoh.com" />
-            </Form.Control>
-          </Form.Field>
+          <Form.Field name="slogan" className="space-y-2"><Form.Label asChild><Label.Root className="input-label">Slogan</Label.Root></Form.Label><Form.Control asChild><input type="text" name="slogan" value={formData.slogan || ''} onChange={(e) => setFormData(p => ({...p, slogan: e.target.value}))} className="input-field" placeholder="Slogan Perusahaan" /></Form.Control></Form.Field>
+          <Form.Field name="email" className="space-y-2"><Form.Label asChild><Label.Root className="input-label">Email</Label.Root></Form.Label><Form.Control asChild><input type="email" name="email" value={formData.email || ''} onChange={(e) => setFormData(p => ({...p, email: e.target.value}))} className="input-field" placeholder="kontak@contoh.com" /></Form.Control></Form.Field>
         </Section>
 
         <Section title="Alamat" icon={MapPinIcon}>
-          {formData.addresses.map((addr, index) => (
-            <AddressItemForm
-              key={addr.id}
-              item={addr}
-              index={index}
-              onUpdate={(id, field, value) => handleArrayChange('addresses', id, field, value)}
-              onPositionChange={handleAddressPositionChange}
-              onRemove={() => removeArrayItem('addresses', addr.id)}
+            <SortableSection<AddressItem>
+                items={formData.addresses}
+                onReorder={(reordered) => setFormData(p => ({ ...p, addresses: reordered }))}
+                renderItem={(item, index) => (
+                    <AddressItemForm
+                        item={item}
+                        index={index}
+                        onUpdate={(id, field, value) => setFormData(p => ({ ...p, addresses: p.addresses.map(i => i.id === id ? { ...i, [field]: value } : i) }))}
+                        onPositionChange={(id, lat, lng) => setFormData(p => ({ ...p, addresses: p.addresses.map(i => i.id === id ? { ...i, latitude: lat, longitude: lng } : i) }))}
+                        onRemove={(id) => setFormData(p => ({ ...p, addresses: p.addresses.filter(i => i.id !== id) }))}
+                    />
+                )}
             />
-          ))}
-          <button type="button" onClick={() => addArrayItem<AddressItem>('addresses', { text: '', latitude: null, longitude: null, notes: '' })} className="secondary-button flex items-center gap-2">
-            <PlusIcon className="w-4 h-4" /> Tambah Alamat
-          </button>
+          <button type="button" onClick={() => setFormData(p => ({...p, addresses: [...p.addresses, {id: uuidv4(), text: '', latitude: null, longitude: null, notes: ''}] }))} className="secondary-button flex items-center gap-2 mt-4"><PlusIcon className="w-4 h-4" /> Tambah Alamat</button>
         </Section>
 
         <Section title="Nomor Kontak" icon={PhoneIcon}>
-          {formData.phone_numbers.map((phone, index) => (
-            <ContactItemForm
-              key={phone.id}
-              item={phone}
-              index={index}
-              onUpdate={(id, field, value) => handleArrayChange('phone_numbers', id, field, value)}
-              onRemove={() => removeArrayItem('phone_numbers', phone.id)}
+            <SortableSection<ContactItem>
+                items={formData.phone_numbers}
+                onReorder={(reordered) => setFormData(p => ({ ...p, phone_numbers: reordered }))}
+                renderItem={(item) => (
+                    <ContactItemForm
+                        item={item}
+                        onUpdate={(id, field, value) => setFormData(p => ({ ...p, phone_numbers: p.phone_numbers.map(i => i.id === id ? { ...i, [field]: value } : i) }))}
+                        onRemove={(id) => setFormData(p => ({...p, phone_numbers: p.phone_numbers.filter(i => i.id !== id)}))}
+                    />
+                )}
             />
-          ))}
-          <button type="button" onClick={() => addArrayItem<ContactItem>('phone_numbers', { number: '', label: '' })} className="secondary-button flex items-center gap-2">
-            <PlusIcon className="w-4 h-4" /> Tambah Nomor Telepon
-          </button>
+          <button type="button" onClick={() => setFormData(p => ({ ...p, phone_numbers: [...p.phone_numbers, {id: uuidv4(), number: '', label: ''}]}))} className="secondary-button flex items-center gap-2 mt-4"><PlusIcon className="w-4 h-4" /> Tambah Nomor Telepon</button>
         </Section>
 
         <Section title="Media Sosial" icon={GlobeAltIcon}>
-          {formData.social_media_links.map((link, index) => (
-            <SocialMediaItemForm
-              key={link.id}
-              item={link}
-              index={index}
-              onUpdate={(id, field, value) => handleArrayChange('social_media_links', id, field, value)}
-              onRemove={() => removeArrayItem('social_media_links', link.id)}
+            <SortableSection<SocialMediaLink>
+                items={formData.social_media_links}
+                onReorder={(reordered) => setFormData(p => ({ ...p, social_media_links: reordered }))}
+                renderItem={(item) => (
+                    <SocialMediaItemForm
+                        item={item}
+                        onUpdate={(id, field, value) => setFormData(p => ({ ...p, social_media_links: p.social_media_links.map(i => i.id === id ? { ...i, [field]: value } : i) }))}
+                        onRemove={(id) => setFormData(p => ({...p, social_media_links: p.social_media_links.filter(i => i.id !== id)}))}
+                    />
+                )}
             />
-          ))}
-          <button type="button" onClick={() => addArrayItem<SocialMediaLink>('social_media_links', { platform: '', url: '' })} className="secondary-button flex items-center gap-2">
-            <PlusIcon className="w-4 h-4" /> Tambah Media Sosial
-          </button>
+          <button type="button" onClick={() => setFormData(p => ({ ...p, social_media_links: [...p.social_media_links, {id: uuidv4(), platform: '', url: ''}]}))} className="secondary-button flex items-center gap-2 mt-4"><PlusIcon className="w-4 h-4" /> Tambah Media Sosial</button>
         </Section>
 
-        <Section title="Visi & Misi" icon={VisionIcon}>
-          <Form.Field name="vision" className="space-y-2">
-            <Form.Label asChild><Label.Root className="block text-sm font-medium text-gray-300">Visi</Label.Root></Form.Label>
-            <Form.Control asChild>
-              <textarea name="vision" rows={4} value={formData.vision || ''} onChange={handleChange} className="input-field resize-none" placeholder="Pernyataan Visi Perusahaan" />
-            </Form.Control>
-          </Form.Field>
-          <Form.Field name="mission" className="space-y-2">
-            <Form.Label asChild><Label.Root className="block text-sm font-medium text-gray-300">Misi</Label.Root></Form.Label>
-            <Form.Control asChild>
-              <textarea name="mission" rows={6} value={formData.mission || ''} onChange={handleChange} className="input-field resize-none" placeholder="Pernyataan Misi Perusahaan" />
-            </Form.Control>
-          </Form.Field>
+        <Section title="Visi & Misi" icon={EyeIcon}>
+          <Form.Field name="vision" className="space-y-2"><Form.Label asChild><Label.Root className="input-label">Visi</Label.Root></Form.Label><Form.Control asChild><textarea name="vision" rows={4} value={formData.vision || ''} onChange={(e) => setFormData(p => ({...p, vision: e.target.value}))} className="input-field resize-none" placeholder="Pernyataan Visi Perusahaan" /></Form.Control></Form.Field>
+          <Form.Field name="mission" className="space-y-2"><Form.Label asChild><Label.Root className="input-label">Misi</Label.Root></Form.Label><Form.Control asChild><textarea name="mission" rows={6} value={formData.mission || ''} onChange={(e) => setFormData(p => ({...p, mission: e.target.value}))} className="input-field resize-none" placeholder="Pernyataan Misi Perusahaan" /></Form.Control></Form.Field>
         </Section>
 
         <Section title="Struktur Organisasi" icon={UsersIcon}>
-          {formData.organizational_structure.map((member, index) => (
-            <OrganizationMemberForm
-              key={member.id}
-              item={member}
-              index={index}
-              onUpdate={(id, field, value) => handleArrayChange('organizational_structure', id, field, value)}
-              onRemove={() => removeArrayItem('organizational_structure', member.id)}
+            <SortableSection<OrganizationMember>
+                items={formData.organizational_structure}
+                onReorder={(reordered) => setFormData(p => ({ ...p, organizational_structure: reordered }))}
+                renderItem={(item) => (
+                    <OrganizationMemberForm
+                        item={item}
+                        onUpdate={(id, field, value) => setFormData(p => ({ ...p, organizational_structure: p.organizational_structure.map(i => i.id === id ? { ...i, [field]: value } : i) }))}
+                        onRemove={(id) => setFormData(p => ({...p, organizational_structure: p.organizational_structure.filter(i => i.id !== id)}))}
+                    />
+                )}
             />
-          ))}
-          <button type="button" onClick={() => addArrayItem<OrganizationMember>('organizational_structure', { position: '', name: '' })} className="secondary-button flex items-center gap-2">
-            <PlusIcon className="w-4 h-4" /> Tambah Anggota
-          </button>
+          <button type="button" onClick={() => setFormData(p => ({ ...p, organizational_structure: [...p.organizational_structure, {id: uuidv4(), position: '', name: ''}]}))} className="secondary-button flex items-center gap-2 mt-4"><PlusIcon className="w-4 h-4" /> Tambah Anggota</button>
+        </Section>
+
+        <Section title="Kemitraan" icon={BriefcaseIcon}>
+          <div className="space-y-6">
+            <div>
+              <div className="flex items-center gap-3 mb-4"><AcademicCapIcon className="w-5 h-5 text-gray-300" /><h4 className="text-lg font-medium text-gray-300">Lembaga Pendidikan, Pemerintah, & Swasta</h4></div>
+              <SortableSection<PartnershipItem>
+                  items={educationPartners}
+                  onReorder={(reordered) => setFormData(p => ({ ...p, partnerships: [...reordered, ...industryPartners] }))}
+                  renderItem={(item) => (
+                      <PartnershipItemForm item={item} onUpdate={(id, field, value) => setFormData(p => ({ ...p, partnerships: p.partnerships.map(i => i.id === id ? { ...i, [field]: value } : i) }))} onRemove={(id) => setFormData(p => ({ ...p, partnerships: p.partnerships.filter(i => i.id !== id) }))} />
+                  )} />
+              <button type="button" onClick={() => setFormData(p => ({ ...p, partnerships: [...p.partnerships, { id: uuidv4(), category: 'education_government', name: '', logo_url: null }] }))} className="secondary-button flex items-center gap-2 mt-4"><PlusIcon className="w-4 h-4" /> Tambah Mitra Pendidikan/Pemerintah</button>
+            </div>
+            <div>
+              <div className="flex items-center gap-3 mb-4"><BriefcaseIcon className="w-5 h-5 text-gray-300" /><h4 className="text-lg font-medium text-gray-300">Mitra Industri</h4></div>
+              <SortableSection<PartnershipItem>
+                  items={industryPartners}
+                  onReorder={(reordered) => setFormData(p => ({ ...p, partnerships: [...educationPartners, ...reordered] }))}
+                  renderItem={(item) => (
+                      <PartnershipItemForm item={item} onUpdate={(id, field, value) => setFormData(p => ({ ...p, partnerships: p.partnerships.map(i => i.id === id ? { ...i, [field]: value } : i) }))} onRemove={(id) => setFormData(p => ({ ...p, partnerships: p.partnerships.filter(i => i.id !== id) }))} />
+                  )} />
+              <button type="button" onClick={() => setFormData(p => ({ ...p, partnerships: [...p.partnerships, { id: uuidv4(), category: 'industry', name: '', logo_url: null }] }))} className="secondary-button flex items-center gap-2 mt-4"><PlusIcon className="w-4 h-4" /> Tambah Mitra Industri</button>
+            </div>
+          </div>
         </Section>
 
         <div className="flex justify-end pt-4">
           <Form.Submit asChild>
-            <button
-              type="submit"
-              disabled={isSaving}
-              className="primary-button"
-            >
-              {isSaving ? (
-                <>
-                  <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />
-                  Menyimpan...
-                </>
-              ) : (
-                'Simpan Profil'
-              )}
+            <button type="submit" disabled={isSaving} className="primary-button">
+              {isSaving ? (<><div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2" />Menyimpan...</>) : 'Simpan Profil'}
             </button>
           </Form.Submit>
         </div>

--- a/src/components/admin/ProductsTab.tsx
+++ b/src/components/admin/ProductsTab.tsx
@@ -16,6 +16,9 @@ import {
   ClockIcon,
   TagIcon,
   PencilSquareIcon,
+  MagnifyingGlassIcon,
+  XMarkIcon,
+  LinkIcon,
 } from '@heroicons/react/24/outline';
 import type { Product, ProductDraft, ProductType } from "@/types/supabase";
 
@@ -33,59 +36,80 @@ interface ProductsTabProps {
   onAddType: (name: string) => Promise<void>;
   onDeleteType: (id: string) => Promise<void>;
   onUpdateType: (id: string, name: string) => Promise<void>;
+  searchTerm: string;
+  onSearchChange: (term: string) => void;
 }
 
 const StatusBadge = ({ published }: { published: boolean }) => (
   <span className={`inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold border transition-all duration-200 ${
-    published 
-      ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30 shadow-emerald-500/20' 
+    published
+      ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30 shadow-emerald-500/20'
       : 'bg-amber-500/10 text-amber-400 border-amber-500/30 shadow-amber-500/20'
   }`}>
-    {published ? (
-      <>
-        <CheckCircleIcon className="w-3.5 h-3.5 mr-1.5" />
-        Diterbitkan
-      </>
-    ) : (
-      <>
-        <ClockIcon className="w-3.5 h-3.5 mr-1.5" />
-        Draf
-      </>
-    )}
+    {published ? <CheckCircleIcon className="w-3.5 h-3.5 mr-1.5" /> : <ClockIcon className="w-3.5 h-3.5 mr-1.5" />}
+    {published ? 'Diterbitkan' : 'Draf'}
   </span>
 );
 
-const ActionButton = ({
-  onClick,
-  icon: Icon,
-  children,
-  variant = "secondary",
-  disabled = false
-}: {
-  onClick: () => void;
+const ActionButton = React.forwardRef<HTMLButtonElement, {
+  onClick: (e: React.MouseEvent) => void;
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   children: React.ReactNode;
   variant?: "primary" | "secondary" | "danger" | "success";
   disabled?: boolean;
-}) => {
+}>(({ onClick, icon: Icon, children, variant = "secondary", disabled = false }, ref) => {
   const variants = {
     primary: "bg-red-500/10 hover:bg-red-500/20 text-red-400 border-red-500/30",
     secondary: "bg-slate-500/10 hover:bg-slate-500/20 text-slate-400 border-slate-500/30",
     danger: "bg-red-500/10 hover:bg-red-500/20 text-red-400 border-red-500/30",
-    success: "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border-emerald-500/30"
+    success: "bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
   };
-
   return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={`px-3 py-1.5 text-xs font-semibold rounded-lg border transition-all duration-200 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]}`}
-    >
+    <button ref={ref} onClick={onClick} disabled={disabled} className={`px-3 py-1.5 text-xs font-semibold rounded-lg border transition-all duration-200 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]}`}>
       <Icon className="w-3.5 h-3.5" />
       {children}
     </button>
   );
+});
+ActionButton.displayName = 'ActionButton';
+
+
+const ConfirmationDialog = ({ trigger, title, description, onConfirm, confirmButtonText, confirmButtonVariant }: {
+    trigger: React.ReactNode;
+    title: string;
+    description: React.ReactNode;
+    onConfirm: () => void;
+    confirmButtonText: string;
+    confirmButtonVariant: 'danger' | 'success' | 'warning' | 'default';
+}) => {
+    const variantClasses = {
+        danger: 'bg-red-600 hover:bg-red-700',
+        success: 'bg-emerald-600 hover:bg-emerald-700',
+        warning: 'bg-amber-600 hover:bg-amber-700',
+        default: 'bg-slate-600 hover:bg-slate-700',
+    };
+    return (
+        <AlertDialog.Root>
+            <AlertDialog.Trigger asChild>{trigger}</AlertDialog.Trigger>
+            <AlertDialog.Portal>
+                <AlertDialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
+                <AlertDialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-slate-800 rounded-2xl p-8 w-full max-w-md z-50 border border-slate-700 shadow-2xl">
+                    <AlertDialog.Title className="text-xl font-semibold text-white mb-2">{title}</AlertDialog.Title>
+                    <AlertDialog.Description className="text-slate-400 mb-6">{description}</AlertDialog.Description>
+                    <div className="flex gap-3 justify-end">
+                        <AlertDialog.Cancel asChild>
+                            <button className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-xl transition-colors">Batal</button>
+                        </AlertDialog.Cancel>
+                        <AlertDialog.Action asChild>
+                            <button onClick={onConfirm} className={`px-4 py-2 text-white rounded-xl transition-colors ${variantClasses[confirmButtonVariant]}`}>{confirmButtonText}</button>
+                        </AlertDialog.Action>
+                    </div>
+                </AlertDialog.Content>
+            </AlertDialog.Portal>
+        </AlertDialog.Root>
+    );
 };
+
 
 export function ProductsTab({
   products,
@@ -100,11 +124,18 @@ export function ProductsTab({
   onAddType,
   onDeleteType,
   onUpdateType,
+  searchTerm,
+  onSearchChange,
 }: ProductsTabProps) {
   const [newTypeName, setNewTypeName] = useState('');
   const [isEditTypeDialogOpen, setIsEditTypeDialogOpen] = useState(false);
   const [editingProductType, setEditingProductType] = useState<ProductType | null>(null);
   const [editedProductTypeName, setEditedProductTypeName] = useState('');
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+
+  const handleViewDetails = (product: Product) => {
+    setSelectedProduct(product);
+  };
 
   const handleAddTypeSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -163,6 +194,19 @@ export function ProductsTab({
         </div>
       </div>
 
+      <div className="mb-8">
+        <div className="relative">
+          <MagnifyingGlassIcon className="absolute left-6 top-1/2 -translate-y-1/2 w-6 h-6 text-slate-400 pointer-events-none" />
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Cari produk berdasarkan nama..."
+            className="w-full pl-16 pr-6 py-4 bg-slate-800/60 backdrop-blur-sm border border-slate-700/50 text-white rounded-2xl focus:ring-2 focus:ring-red-500/50 focus:border-red-500/50 transition-all duration-200 placeholder-slate-400 text-lg"
+          />
+        </div>
+      </div>
+
       <div className="bg-slate-800/40 backdrop-blur-xl rounded-3xl border border-slate-700/50 overflow-hidden shadow-2xl">
         <div className="overflow-x-auto">
           <table className="w-full">
@@ -184,11 +228,11 @@ export function ProductsTab({
             </thead>
             <tbody className="divide-y divide-slate-700/30">
               {products.map(product => (
-                <tr key={product.id} className="group hover:bg-slate-700/20 transition-all duration-200">
+                <tr key={product.id} onClick={() => handleViewDetails(product)} className="group hover:bg-slate-700/20 transition-all duration-200 cursor-pointer">
                   <td className="px-8 py-6">
                     <div className="flex items-center gap-4">
                       {product.image_urls?.[0] ? (
-                        <div className="relative w-16 h-16 rounded-2xl overflow-hidden bg-slate-700/50 border border-slate-600/50">
+                        <div className="relative w-16 h-16 rounded-2xl overflow-hidden bg-slate-700/50 border border-slate-600/50 flex-shrink-0">
                           <Image
                             src={product.image_urls[0]}
                             alt={product.name}
@@ -197,7 +241,7 @@ export function ProductsTab({
                           />
                         </div>
                       ) : (
-                        <div className="w-16 h-16 bg-slate-700/50 rounded-2xl border border-slate-600/50 flex items-center justify-center">
+                        <div className="w-16 h-16 bg-slate-700/50 rounded-2xl border border-slate-600/50 flex items-center justify-center flex-shrink-0">
                           <CubeIcon className="w-8 h-8 text-slate-500" />
                         </div>
                       )}
@@ -220,114 +264,57 @@ export function ProductsTab({
                     <StatusBadge published={product.is_published} />
                   </td>
                   <td className="px-8 py-6">
-                    <div className="flex justify-end gap-2">
-                      <ActionButton
-                        onClick={() => onEditProduct(product)}
-                        icon={PencilIcon}
-                        variant="secondary"
-                      >
+                    <div className="flex justify-end gap-2" onClick={(e) => e.stopPropagation()}>
+                      <ActionButton onClick={() => onEditProduct(product)} icon={PencilIcon} variant="secondary">
                         Sunting
                       </ActionButton>
 
-                      <AlertDialog.Root>
-                        <AlertDialog.Trigger asChild>
-                          <ActionButton
-                            onClick={() => {}}
-                            icon={product.is_published ? EyeSlashIcon : EyeIcon}
-                            variant={product.is_published ? "secondary" : "success"}
-                          >
-                            {product.is_published ? 'Batal Terbit' : 'Terbitkan'}
-                          </ActionButton>
-                        </AlertDialog.Trigger>
-                        <AlertDialog.Portal>
-                          <AlertDialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
-                          <AlertDialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-slate-800 rounded-2xl p-8 w-full max-w-md z-50 border border-slate-700 shadow-2xl">
-                            <AlertDialog.Title className="text-xl font-semibold text-white mb-2">
-                              {product.is_published ? 'Batalkan Penerbitan' : 'Terbitkan'} Produk
-                            </AlertDialog.Title>
-                            <AlertDialog.Description className="text-slate-400 mb-6">
-                              Apakah Anda yakin ingin {product.is_published ? 'menyembunyikan' : 'menerbitkan'} &quot;{product.name}&quot;?
-                            </AlertDialog.Description>
-                            <div className="flex gap-3 justify-end">
-                              <AlertDialog.Cancel asChild>
-                                <button className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-xl transition-colors">
-                                  Batal
-                                </button>
-                              </AlertDialog.Cancel>
-                              <AlertDialog.Action asChild>
-                                <button
-                                  onClick={() => onTogglePublish(product)}
-                                  className={`px-4 py-2 text-white rounded-xl transition-colors ${
-                                    product.is_published 
-                                      ? 'bg-amber-600 hover:bg-amber-700' 
-                                      : 'bg-emerald-600 hover:bg-emerald-700'
-                                  }`}
-                                >
-                                  {product.is_published ? 'Batal Terbit' : 'Terbitkan'}
-                                </button>
-                              </AlertDialog.Action>
-                            </div>
-                          </AlertDialog.Content>
-                        </AlertDialog.Portal>
-                      </AlertDialog.Root>
+                      <ConfirmationDialog
+                          trigger={
+                            <ActionButton onClick={(e) => e.stopPropagation()} icon={product.is_published ? EyeSlashIcon : EyeIcon} variant={product.is_published ? "secondary" : "success"}>
+                                {product.is_published ? 'Batal Terbit' : 'Terbitkan'}
+                            </ActionButton>
+                          }
+                          title={`${product.is_published ? 'Batalkan Penerbitan' : 'Terbitkan'} Produk`}
+                          description={`Apakah Anda yakin ingin ${product.is_published ? 'menyembunyikan' : 'menerbitkan'} “${product.name}”?`}
+                          onConfirm={() => onTogglePublish(product)}
+                          confirmButtonText={product.is_published ? 'Batal Terbit' : 'Terbitkan'}
+                          confirmButtonVariant={product.is_published ? 'warning' : 'success'}
+                      />
 
-                      <AlertDialog.Root>
-                        <AlertDialog.Trigger asChild>
-                          <ActionButton
-                            onClick={() => {}}
-                            icon={TrashIcon}
-                            variant="danger"
-                          >
-                            Hapus
-                          </ActionButton>
-                        </AlertDialog.Trigger>
-                        <AlertDialog.Portal>
-                          <AlertDialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
-                          <AlertDialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-slate-800 rounded-2xl p-8 w-full max-w-md z-50 border border-slate-700 shadow-2xl">
-                            <AlertDialog.Title className="text-xl font-semibold text-white mb-2">
-                              Hapus Produk
-                            </AlertDialog.Title>
-                            <AlertDialog.Description className="text-slate-400 mb-6">
-                              Apakah Anda yakin ingin menghapus &quot;{product.name}&quot;? Tindakan ini tidak dapat dibatalkan dan juga akan menghapus semua draf terkait.
-                            </AlertDialog.Description>
-                            <div className="flex gap-3 justify-end">
-                              <AlertDialog.Cancel asChild>
-                                <button className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-xl transition-colors">
-                                  Batal
-                                </button>
-                              </AlertDialog.Cancel>
-                              <AlertDialog.Action asChild>
-                                <button
-                                  onClick={() => onDeleteProduct(product.id)}
-                                  className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-xl transition-colors"
-                                >
-                                  Hapus
-                                </button>
-                              </AlertDialog.Action>
-                            </div>
-                          </AlertDialog.Content>
-                        </AlertDialog.Portal>
-                      </AlertDialog.Root>
+                      <ConfirmationDialog
+                          trigger={
+                            <ActionButton onClick={(e) => e.stopPropagation()} icon={TrashIcon} variant="danger">
+                                Hapus
+                            </ActionButton>
+                          }
+                          title="Hapus Produk"
+                          description={`Apakah Anda yakin ingin menghapus “${product.name}”? Tindakan ini tidak dapat dibatalkan.`}
+                          onConfirm={() => onDeleteProduct(product.id)}
+                          confirmButtonText="Hapus"
+                          confirmButtonVariant="danger"
+                      />
                     </div>
                   </td>
                 </tr>
               ))}
-
               {!products.length && !isDataLoading && (
                 <tr>
                   <td colSpan={4} className="px-8 py-16 text-center">
                     <div className="flex flex-col items-center">
                       <div className="w-20 h-20 bg-slate-700/50 rounded-3xl flex items-center justify-center mb-6">
-                        <CubeIcon className="w-10 h-10 text-slate-500" />
+                        <MagnifyingGlassIcon className="w-10 h-10 text-slate-500" />
                       </div>
-                      <h3 className="text-xl font-semibold text-slate-300 mb-2">Tidak ada produk yang ditemukan</h3>
-                      <p className="text-slate-500 mb-6">Buat produk pertama Anda untuk memulai</p>
-                      <button
-                        onClick={onCreateNewProduct}
-                        className="px-6 py-3 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white font-semibold rounded-xl transition-all duration-300"
-                      >
-                        Buat Produk
-                      </button>
+                      <h3 className="text-xl font-semibold text-slate-300 mb-2">Tidak ada produk yang cocok</h3>
+                      <p className="text-slate-500 mb-6">{searchTerm ? 'Coba kata kunci lain atau bersihkan pencarian.' : 'Buat produk pertama Anda untuk memulai.'}</p>
+                      {!searchTerm && (
+                        <button
+                          onClick={onCreateNewProduct}
+                          className="px-6 py-3 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white font-semibold rounded-xl transition-all duration-300"
+                        >
+                          Buat Produk
+                        </button>
+                      )}
                     </div>
                   </td>
                 </tr>
@@ -336,13 +323,11 @@ export function ProductsTab({
           </table>
         </div>
       </div>
-
       <div className="mt-12">
         <h2 className="text-3xl font-bold bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent mb-2">
           Tipe Produk
         </h2>
         <p className="text-slate-400 mb-8">Atur produk Anda dengan kategori khusus</p>
-
         <div className="bg-slate-800/40 backdrop-blur-xl rounded-3xl p-8 border border-slate-700/50 shadow-2xl">
           <div className="mb-8">
             <h3 className="text-xl font-semibold text-white mb-4 flex items-center gap-3">
@@ -351,7 +336,6 @@ export function ProductsTab({
               </div>
               Tambah Tipe Baru
             </h3>
-
             <Form.Root onSubmit={handleAddTypeSubmit}>
               <div className="flex gap-4">
                 <Form.Field name="typeName" className="flex-1">
@@ -365,7 +349,6 @@ export function ProductsTab({
                     />
                   </Form.Control>
                 </Form.Field>
-
                 <Form.Submit asChild>
                   <button
                     type="submit"
@@ -379,7 +362,6 @@ export function ProductsTab({
               </div>
             </Form.Root>
           </div>
-
           <div>
             <h3 className="text-xl font-semibold text-white mb-6 flex items-center gap-3">
               <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-blue-600 rounded-xl flex items-center justify-center">
@@ -387,7 +369,6 @@ export function ProductsTab({
               </div>
               Tipe yang Ada ({productTypes.length})
             </h3>
-
             {!productTypes.length && !isDataLoading ? (
               <div className="text-center py-16">
                 <div className="w-20 h-20 bg-slate-700/50 rounded-3xl flex items-center justify-center mx-auto mb-6">
@@ -413,7 +394,6 @@ export function ProductsTab({
                         </p>
                       </div>
                     </div>
-
                     <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
                         <button
                             onClick={() => openEditTypeDialog(type)}
@@ -423,44 +403,19 @@ export function ProductsTab({
                             <PencilSquareIcon className="w-4 h-4" />
                             Sunting
                         </button>
-                        <AlertDialog.Root>
-                        <AlertDialog.Trigger asChild>
-                            <button
-                            disabled={isProcessing}
-                            className="px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/30 font-semibold rounded-xl transition-all duration-200 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                            <TrashIcon className="w-4 h-4" />
-                            Hapus
-                            </button>
-                        </AlertDialog.Trigger>
-
-                        <AlertDialog.Portal>
-                            <AlertDialog.Overlay className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
-                            <AlertDialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-slate-800 rounded-2xl p-8 w-full max-w-md z-50 border border-slate-700 shadow-2xl">
-                            <AlertDialog.Title className="text-xl font-semibold text-white mb-2">
-                                Hapus Tipe Produk
-                            </AlertDialog.Title>
-                            <AlertDialog.Description className="text-slate-400 mb-6">
-                                Apakah Anda yakin ingin menghapus tipe produk &quot;{type.name}&quot;? Tindakan ini tidak dapat dibatalkan dan dapat memengaruhi produk yang ada.
-                            </AlertDialog.Description>
-                            <div className="flex gap-3 justify-end">
-                                <AlertDialog.Cancel asChild>
-                                <button className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-xl transition-colors">
-                                    Batal
-                                </button>
-                                </AlertDialog.Cancel>
-                                <AlertDialog.Action asChild>
-                                <button
-                                    onClick={() => onDeleteType(type.id)}
-                                    className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-xl transition-colors"
-                                >
-                                    Hapus
-                                </button>
-                                </AlertDialog.Action>
-                            </div>
-                            </AlertDialog.Content>
-                        </AlertDialog.Portal>
-                        </AlertDialog.Root>
+                        <ConfirmationDialog
+                          trigger={
+                             <button disabled={isProcessing} className="px-3 py-1.5 bg-red-500/10 hover:bg-red-500/20 text-red-400 border border-red-500/30 font-semibold rounded-xl transition-all duration-200 flex items-center gap-1.5 disabled:opacity-50 disabled:cursor-not-allowed">
+                                <TrashIcon className="w-4 h-4" />
+                                Hapus
+                             </button>
+                          }
+                          title="Hapus Tipe Produk"
+                          description={`Apakah Anda yakin ingin menghapus tipe produk “${type.name}”? Tindakan ini tidak dapat dibatalkan.`}
+                          onConfirm={() => onDeleteType(type.id)}
+                          confirmButtonText="Hapus"
+                          confirmButtonVariant="danger"
+                      />
                     </div>
                   </div>
                 ))}
@@ -469,7 +424,6 @@ export function ProductsTab({
           </div>
         </div>
       </div>
-
       <AlertDialog.Root open={isEditTypeDialogOpen} onOpenChange={setIsEditTypeDialogOpen}>
         <AlertDialog.Portal>
           <AlertDialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
@@ -478,9 +432,8 @@ export function ProductsTab({
               Sunting Tipe Produk
             </AlertDialog.Title>
             <AlertDialog.Description className="text-slate-400 mb-6 text-lg">
-              Perbarui nama untuk &quot;{editingProductType?.name}&quot;.
+              Perbarui nama untuk “{editingProductType?.name}”.
             </AlertDialog.Description>
-
             <Form.Root onSubmit={handleUpdateTypeSubmit}>
               <Form.Field name="editTypeName" className="mb-6">
                 <Form.Label className="block text-sm font-semibold text-slate-300 mb-2">
@@ -500,7 +453,6 @@ export function ProductsTab({
                   Nama tipe tidak boleh kosong.
                 </Form.Message>
               </Form.Field>
-
               <div className="flex gap-4 justify-end">
                 <AlertDialog.Cancel asChild>
                   <button type="button" className="px-6 py-3 bg-slate-700 hover:bg-slate-600 text-white font-medium rounded-xl transition-all duration-200">
@@ -521,6 +473,89 @@ export function ProductsTab({
           </AlertDialog.Content>
         </AlertDialog.Portal>
       </AlertDialog.Root>
+      <Dialog.Root open={!!selectedProduct} onOpenChange={(isOpen) => !isOpen && setSelectedProduct(null)}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+          <Dialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-full max-w-4xl max-h-[90vh] bg-slate-800/95 backdrop-blur-xl rounded-3xl border border-slate-700/50 shadow-2xl z-50 flex flex-col data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+            {selectedProduct && (
+              <>
+                <div className="flex justify-between items-center p-6 border-b border-slate-700/50 flex-shrink-0">
+                  <Dialog.Title className="text-2xl font-bold text-white">
+                    Detail Produk
+                  </Dialog.Title>
+                  <Dialog.Close asChild>
+                    <button className="p-2 text-slate-400 hover:text-white hover:bg-slate-700/50 rounded-full transition-all">
+                      <XMarkIcon className="w-6 h-6" />
+                    </button>
+                  </Dialog.Close>
+                </div>
+                <div className="p-8 overflow-y-auto">
+                  <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                    <div>
+                      {selectedProduct.image_urls && selectedProduct.image_urls.length > 0 ? (
+                        <div className="space-y-4">
+                          <div className="relative aspect-square w-full rounded-2xl overflow-hidden border border-slate-700">
+                            <Image src={selectedProduct.image_urls[0]} alt={selectedProduct.name} fill className="object-cover"/>
+                          </div>
+                          {selectedProduct.image_urls.length > 1 && (
+                             <div className="grid grid-cols-4 gap-3">
+                                {selectedProduct.image_urls.slice(1, 5).map((url, index) => (
+                                  <div key={index} className="relative aspect-square w-full rounded-lg overflow-hidden border border-slate-700">
+                                    <Image src={url} alt={`${selectedProduct.name} image ${index + 2}`} fill className="object-cover" />
+                                  </div>
+                                ))}
+                             </div>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="aspect-square w-full bg-slate-700/50 rounded-2xl border border-slate-600/50 flex items-center justify-center">
+                          <CubeIcon className="w-24 h-24 text-slate-500" />
+                        </div>
+                      )}
+                    </div>
+                    <div className="space-y-6">
+                      <h3 className="text-4xl font-bold bg-gradient-to-r from-red-400 via-red-500 to-red-600 bg-clip-text text-transparent">
+                        {selectedProduct.name}
+                      </h3>
+                      <div className="flex flex-wrap gap-4 items-center">
+                        <StatusBadge published={selectedProduct.is_published} />
+                        <span className="inline-flex items-center px-3 py-1.5 rounded-full text-xs font-semibold bg-blue-500/10 text-blue-400 border border-blue-500/30">
+                          {selectedProduct.product_types?.name || 'Tanpa Kategori'}
+                        </span>
+                      </div>
+                      <div>
+                        <h4 className="font-semibold text-slate-300 text-lg mb-2">Deskripsi</h4>
+                        <p className="text-slate-400 leading-relaxed whitespace-pre-wrap">
+                          {selectedProduct.description || 'Tidak ada deskripsi untuk produk ini.'}
+                        </p>
+                      </div>
+
+                      {selectedProduct.store_links && selectedProduct.store_links.length > 0 && (
+                        <div>
+                           <h4 className="font-semibold text-slate-300 text-lg mb-3">Tautan Toko</h4>
+                           <div className="space-y-3">
+                            {selectedProduct.store_links.map((link, index) => (
+                              <a href={link.url} target="_blank" rel="noopener noreferrer" key={index} className="flex items-center gap-3 p-4 bg-slate-700/50 rounded-xl border border-slate-600/50 hover:border-red-500/50 hover:bg-slate-700/80 transition-all duration-200">
+                                <div className="p-2 bg-slate-600/50 rounded-lg">
+                                    <LinkIcon className="w-5 h-5 text-red-400" />
+                                </div>
+                                <div className="flex-1 overflow-hidden">
+                                    <p className="font-medium text-white truncate">{link.name || new URL(link.url).hostname}</p>
+                                    <p className="text-xs text-slate-400 truncate">{link.url}</p>
+                                </div>
+                              </a>
+                            ))}
+                           </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </>
+            )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </Tabs.Content>
   );
 }

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/router";
 import {
   signOut, supabase, getProductTypes, createProductType, deleteProductType,
@@ -48,6 +48,7 @@ export default function AdminPage() {
   const [toastOpen, setToastOpen] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
   const [toastType, setToastType] = useState<'success' | 'error'>('success');
+  const [searchTerm, setSearchTerm] = useState('');
 
   const showToast = (message: string, type: 'success' | 'error' = 'success') => {
     setToastMessage(message);
@@ -419,6 +420,17 @@ export default function AdminPage() {
     openFormForNewProduct().catch(console.error);
   };
 
+  const filteredProducts = useMemo(() => {
+    if (!searchTerm) {
+      return products;
+    }
+    const lowercasedTerm = searchTerm.toLowerCase();
+    return products.filter(product =>
+      product.name.toLowerCase().includes(lowercasedTerm) ||
+      (product.description && product.description.toLowerCase().includes(lowercasedTerm))
+    );
+  }, [products, searchTerm]);
+
   const LoadingSpinner = () => (
     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-red-400"></div>
   );
@@ -561,7 +573,7 @@ export default function AdminPage() {
               />
 
               <ProductsTab
-                products={products}
+                products={filteredProducts}
                 userDrafts={userDrafts}
                 setShowDraftsDialog={setShowDraftsDialog}
                 onCreateNewProduct={handleCreateNewProduct}
@@ -574,6 +586,8 @@ export default function AdminPage() {
                 onAddType={handleAddProductType}
                 onDeleteType={handleDeleteProductType}
                 onUpdateType={handleUpdateProductType}
+                searchTerm={searchTerm}
+                onSearchChange={setSearchTerm}
               />
 
               <ProfileTab
@@ -767,18 +781,13 @@ export default function AdminPage() {
                                     </AlertDialog.Description>
                                     <div className="flex gap-3 justify-end">
                                       <AlertDialog.Cancel asChild>
-                                        <button className="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-xl transition-colors">
-                                          Batal
-                                        </button>
-                                      </AlertDialog.Cancel>
-                                      <AlertDialog.Action asChild>
                                         <button
                                           onClick={() => handleDeleteUserDraft(draft.id)}
                                           className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-xl transition-colors"
                                         >
                                           Hapus
                                         </button>
-                                      </AlertDialog.Action>
+                                      </AlertDialog.Cancel>
                                     </div>
                                   </AlertDialog.Content>
                                 </AlertDialog.Portal>

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -1,4 +1,3 @@
-// types/supabase.d.ts
 export interface ProductType {
   id: string;
   name: string;
@@ -71,8 +70,15 @@ export interface OrganizationMember {
   name: string;
 }
 
+export interface PartnershipItem {
+  id: string;
+  category: 'education_government' | 'industry';
+  name: string;
+  logo_url: string | null;
+}
+
 export interface OrganizationProfileData {
-  id?: string; // Fixed ID
+  id?: string;
   slogan: string | null;
   addresses: AddressItem[];
   phone_numbers: ContactItem[];
@@ -81,6 +87,7 @@ export interface OrganizationProfileData {
   vision: string | null;
   mission: string | null;
   organizational_structure: OrganizationMember[];
+  partnerships: PartnershipItem[];
   created_at?: string;
   updated_at?: string;
 }


### PR DESCRIPTION
This commit introduces significant UI/UX improvements across the admin panel, focusing on better data management and presentation.

- **feat(products):**
  - Enable drag-and-drop reordering for product images.
  - Add a comprehensive product detail view modal.
  - Implement product search functionality by name and description.
- **feat(organization):**
  - Allow drag-and-drop reordering for addresses, phone numbers, social media, and organizational structure members.
  - Introduce a new 'Partnerships' section with logo upload and categorization (education/government, industry).
- **feat(ui):**
  - Create and integrate a reusable `ConfirmationDialog` for consistent user prompts (e.g., delete, publish actions).
  - Develop a reusable `AlertMessage` component for status feedback on forms.
  - Enhance `ActionButton` component with `forwardRef` for better reusability.
- **refactor:**
  - Optimize login page rendering using `memo` and `useCallback`.
  - Refactor array state management in `OrganizationProfileForm` for DND integration.
  - General UI/UX improvements across admin forms, including better loading, saving feedback, and disabled states.
- **chore:**
  - Add `@dnd-kit` dependencies for drag-and-drop functionality.
  - Update Supabase types to include `PartnershipItem` and related changes.