### PR TITLE
feat: Add admin reports and data export functionality (admin-report-e…

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,17 @@
     "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.1",
+    "leaflet": "^1.9.4",
     "lodash": "^4.17.21",
     "midtrans-client": "^1.4.3",
     "next": "15.3.5",
     "puppeteer-core": "^24.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "leaflet": "^1.9.4",
     "react-leaflet": "^5.0.0",
-    "uuid": "^11.1.0"
+    "recharts": "^3.1.0",
+    "uuid": "^11.1.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -25,6 +25,7 @@ import { ProductsTab } from "@/components/admin/ProductsTab";
 import { ProfileTab } from "@/components/admin/ProfileTab";
 import { TransactionsTab } from "@/components/admin/TransactionsTab";
 import { UsersTab } from "@/components/admin/UsersTab";
+import { ReportsTab } from "@/components/admin/ReportsTab";
 import * as Dialog from '@radix-ui/react-dialog';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import * as Toast from '@radix-ui/react-toast';
@@ -445,6 +446,8 @@ export default function AdminPage() {
         return <UsersTab users={allUsers} currentUserProfile={userProfile} onUpdateUser={handleUpdateUserProfile}
                          onDeleteUser={handleDeleteUserProfile} onCreateUser={handleAdminCreateUser}
                          isProcessing={isProcessing} isDataLoading={isDataLoading}/>;
+      case 'reports':
+        return <ReportsTab />;
       default:
         return (<div className="p-8 text-center">
           <div className="text-slate-400 mb-4"><h2 className="text-2xl font-bold mb-2">Page Not Found</h2><p>The

--- a/src/app/api/admin/export/route.ts
+++ b/src/app/api/admin/export/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { getFullExportData } from '@/lib/supabase';
+import * as XLSX from 'xlsx';
+
+function getCookie(req: NextRequest, name: string): string | undefined {
+  return req.cookies.get(name)?.value;
+}
+
+export async function GET(req: NextRequest) {
+  const response = NextResponse.next();
+  const supabaseRequestClient = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) { return getCookie(req, name); },
+        set(name: string, value: string, options: CookieOptions) { response.cookies.set({ name, value, ...options }); },
+        remove(name: string, options: CookieOptions) { response.cookies.set({ name, value: '', ...options }); },
+      },
+    }
+  );
+
+  const { data: { user } } = await supabaseRequestClient.auth.getUser();
+
+  if (!user || user.app_metadata?.role !== 'admin') {
+    return NextResponse.json({ error: 'Permission denied' }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const reportType = searchParams.get('reportType') as 'financial' | 'users' | 'products' | 'organization_profile' | null;
+
+  if (!reportType) {
+    return NextResponse.json({ error: 'Missing reportType parameter' }, { status: 400 });
+  }
+
+  try {
+    const data = await getFullExportData(reportType);
+
+    if (!data || (Array.isArray(data) && data.length === 0) || (reportType === 'organization_profile' && Object.keys(data).length === 0)) {
+        return NextResponse.json({ error: 'No data available for this report' }, { status: 404 });
+    }
+
+    const wb = XLSX.utils.book_new();
+    let ws;
+
+    if (reportType === 'organization_profile' && typeof data === 'object' && !Array.isArray(data)) {
+        const flattenedData = [
+            { key: 'Slogan', value: data.slogan },
+            { key: 'Email', value: data.email },
+            { key: 'Visi', value: data.vision },
+            { key: 'Misi', value: data.mission },
+            ...(data.addresses || []).map((a: any, i: number) => ({ key: `Alamat ${i+1}`, value: a.text })),
+            ...(data.phone_numbers || []).map((p: any, i: number) => ({ key: `Telepon ${i+1}`, value: `${p.label}: ${p.number}` })),
+            ...(data.social_media_links || []).map((s: any, i: number) => ({ key: `Sosmed ${i+1}`, value: `${s.platform}: ${s.url}` })),
+            ...(data.organizational_structure || []).map((m: any, i: number) => ({ key: `Struktur Organisasi ${i+1}`, value: `${m.position}: ${m.name}`})),
+            ...(data.partnerships || []).map((p: any, i: number) => ({ key: `Kemitraan ${i+1}`, value: `${p.name} (${p.category})`})),
+            ...(data.achievements || []).map((a: any, i: number) => ({ key: `Penghargaan ${i+1}`, value: `${a.title} (${a.year}) - ${a.issuer}`})),
+            ...(data.international_events || []).map((e: any, i: number) => ({ key: `Event Internasional ${i+1}`, value: `${e.country} (${e.country_code})`})),
+        ];
+        ws = XLSX.utils.json_to_sheet(flattenedData, { skipHeader: true });
+    } else {
+        ws = XLSX.utils.json_to_sheet(data);
+    }
+
+    XLSX.utils.book_append_sheet(wb, ws, reportType);
+    const buf = XLSX.write(wb, { type: 'buffer', bookType: 'xlsx' });
+
+    const today = new Date().toISOString().slice(0, 10);
+    const filename = `progress_jogja_${reportType}_report_${today}.xlsx`;
+
+    return new NextResponse(buf, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+
+  } catch (error) {
+    console.error(`Error generating report for ${reportType}:`, error);
+    const errorMessage = error instanceof Error ? error.message : 'An unknown server error occurred';
+    return NextResponse.json({ error: 'Failed to generate report', details: errorMessage }, { status: 500 });
+  }
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -29,9 +29,10 @@ import {
   GlobeAltIcon,
   InformationCircleIcon,
   HandRaisedIcon,
+  DocumentChartBarIcon,
 } from '@heroicons/react/24/outline';
 
-export type AdminTab = 'home' | 'products' | 'profile' | 'transactions' | 'users';
+export type AdminTab = 'home' | 'products' | 'profile' | 'transactions' | 'users' | 'reports';
 
 interface MenuItem {
   id: string;
@@ -84,6 +85,7 @@ const MENU_CONFIG: MenuItem[] = [
       { id: 'profile-settings', label: 'Pengaturan', icon: Cog6ToothIcon },
   ]},
   { id: 'users', label: 'Pengguna', icon: UsersIcon },
+  { id: 'reports', label: 'Laporan', icon: DocumentChartBarIcon },
 ];
 
 export function AdminSidebar({
@@ -122,6 +124,7 @@ export function AdminSidebar({
       'transactions': 'transactions', 'transactions-overview': 'transactions', 'transactions-pending': 'transactions', 'transactions-completed': 'transactions', 'transactions-failed': 'transactions', 'transactions-revenue': 'transactions',
       'profile': 'profile', 'profile-general': 'profile', 'profile-address': 'profile', 'profile-contact': 'profile', 'profile-social': 'profile', 'profile-vision': 'profile', 'profile-structure': 'profile', 'profile-partnerships': 'profile', 'profile-achievements': 'profile', 'profile-events': 'profile', 'profile-settings': 'profile',
       'users': 'users',
+      'reports': 'reports',
     };
 
     const targetTab = tabMapping[item.id] || 'home';

--- a/src/components/admin/ReportsTab.tsx
+++ b/src/components/admin/ReportsTab.tsx
@@ -1,0 +1,211 @@
+import React, { useState, useEffect } from 'react';
+import { getMonthlyRevenueSummary } from '@/lib/supabase';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import {
+  DocumentChartBarIcon,
+  BanknotesIcon,
+  UsersIcon,
+  CubeIcon,
+  BuildingStorefrontIcon,
+  ArrowDownTrayIcon,
+} from '@heroicons/react/24/outline';
+import { motion } from 'framer-motion';
+
+type ReportType = 'financial' | 'users' | 'products' | 'organization_profile';
+type ChartData = { date: string; Pendapatan: number };
+
+const CustomTooltip = ({ active, payload, label }: any) => {
+  if (active && payload && payload.length) {
+    return (
+      <div className="bg-slate-700/80 backdrop-blur-sm p-4 rounded-xl border border-slate-600/50 shadow-lg">
+        <p className="text-sm font-semibold text-slate-300">{label}</p>
+        <p className="text-lg font-bold text-teal-400">
+          {`Rp ${payload[0].value.toLocaleString('id-ID')}`}
+        </p>
+      </div>
+    );
+  }
+  return null;
+};
+
+const ExportCard = ({
+  icon: Icon,
+  title,
+  description,
+  reportType,
+  onExport,
+  isLoading,
+}: {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+  reportType: ReportType;
+  onExport: (type: ReportType) => void;
+  isLoading: boolean;
+}) => (
+  <motion.div
+    initial={{ opacity: 0, y: 20 }}
+    animate={{ opacity: 1, y: 0 }}
+    whileHover={{ y: -5, scale: 1.02 }}
+    className="bg-slate-800/60 backdrop-blur-xl rounded-2xl p-6 border border-slate-700/50 hover:border-slate-600/50 transition-all duration-300 hover:shadow-2xl hover:shadow-slate-900/40 flex flex-col"
+  >
+    <div className="flex items-center gap-4 mb-4">
+      <div className="w-12 h-12 bg-gradient-to-br from-red-500 to-red-600 rounded-xl flex items-center justify-center shadow-lg">
+        <Icon className="w-6 h-6 text-white" />
+      </div>
+      <div>
+        <h3 className="text-lg font-bold text-white">{title}</h3>
+        <p className="text-sm text-slate-400">{description}</p>
+      </div>
+    </div>
+    <div className="flex-grow" />
+    <button
+      onClick={() => onExport(reportType)}
+      disabled={isLoading}
+      className="mt-4 w-full px-6 py-3 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white font-semibold rounded-xl transition-all duration-300 shadow-lg shadow-red-500/25 hover:shadow-red-500/40 disabled:opacity-50 disabled:cursor-wait flex items-center justify-center gap-2"
+    >
+      {isLoading ? (
+        <>
+          <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+          <span>Mengekspor...</span>
+        </>
+      ) : (
+        <>
+          <ArrowDownTrayIcon className="w-5 h-5" />
+          <span>Ekspor ke Excel</span>
+        </>
+      )}
+    </button>
+  </motion.div>
+);
+
+export function ReportsTab() {
+  const [chartData, setChartData] = useState<ChartData[]>([]);
+  const [isChartLoading, setIsChartLoading] = useState(true);
+  const [exportLoading, setExportLoading] = useState<ReportType | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      setIsChartLoading(true);
+      try {
+        const data = await getMonthlyRevenueSummary();
+        const formattedData = data.map(item => ({
+          date: new Date(item.month_start).toLocaleString('id-ID', { month: 'short', year: '2-digit' }),
+          Pendapatan: Number(item.total_revenue),
+        }));
+        setChartData(formattedData);
+      } catch (error) {
+        console.error("Failed to fetch chart data:", error);
+      } finally {
+        setIsChartLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  const handleExport = async (reportType: ReportType) => {
+    setExportLoading(reportType);
+    try {
+      const response = await fetch(`/api/admin/export?reportType=${reportType}`);
+      if (!response.ok) {
+        throw new Error(`Failed to generate report: ${response.statusText}`);
+      }
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      const today = new Date().toISOString().slice(0, 10);
+      a.download = `progress_jogja_${reportType}_${today}.xlsx`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Export failed:", error);
+      alert(`Gagal mengekspor data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setExportLoading(null);
+    }
+  };
+
+  const exportCards = [
+    { icon: BanknotesIcon, title: "Laporan Keuangan", description: "Semua data transaksi dan pendapatan.", reportType: 'financial' as ReportType },
+    { icon: UsersIcon, title: "Data Pengguna", description: "Informasi lengkap semua pengguna terdaftar.", reportType: 'users' as ReportType },
+    { icon: CubeIcon, title: "Data Produk", description: "Katalog lengkap produk dan kategorinya.", reportType: 'products' as ReportType },
+    { icon: BuildingStorefrontIcon, title: "Profil Perusahaan", description: "Ekspor semua data profil organisasi.", reportType: 'organization_profile' as ReportType },
+  ];
+
+  return (
+    <div className="p-8 space-y-12">
+      <div>
+        <div className="flex items-center gap-4 mb-6">
+          <div className="w-12 h-12 bg-gradient-to-br from-red-500 to-red-600 rounded-2xl flex items-center justify-center">
+            <DocumentChartBarIcon className="w-6 h-6 text-white" />
+          </div>
+          <div>
+            <h2 className="text-3xl font-bold bg-gradient-to-r from-white to-slate-300 bg-clip-text text-transparent mb-2">Pusat Laporan</h2>
+            <p className="text-slate-400">Analisis data dan ekspor informasi penting</p>
+          </div>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="bg-slate-800/60 backdrop-blur-xl rounded-3xl p-6 border border-slate-700/50 shadow-2xl shadow-slate-900/50"
+        >
+          <h3 className="text-xl font-bold text-white mb-4">Tinjauan Pendapatan 6 Bulan Terakhir</h3>
+          <div className="h-80 w-full">
+            {isChartLoading ? (
+              <div className="w-full h-full flex items-center justify-center">
+                <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-teal-400"></div>
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={chartData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="colorRevenue" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#2dd4bf" stopOpacity={0.8} />
+                      <stop offset="95%" stopColor="#2dd4bf" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255, 255, 255, 0.1)" />
+                  <XAxis dataKey="date" stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} />
+                  <YAxis stroke="#94a3b8" fontSize={12} tickLine={false} axisLine={false} tickFormatter={(value: number) => `Rp${(value / 1000000).toFixed(1)}jt`} />
+                  <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(45, 212, 191, 0.1)' }} />
+                  <Area type="monotone" dataKey="Pendapatan" stroke="#2dd4bf" fillOpacity={1} fill="url(#colorRevenue)" strokeWidth={2} />
+                </AreaChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </motion.div>
+      </div>
+
+      <div>
+        <h3 className="text-2xl font-bold text-white mb-6">Ekspor Data</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+          {exportCards.map((card, index) => (
+            <motion.div key={card.reportType} initial={{ opacity: 0, scale: 0.9 }} animate={{ opacity: 1, scale: 1 }} transition={{ delay: 0.2 + index * 0.1 }}>
+              <ExportCard
+                icon={card.icon}
+                title={card.title}
+                description={card.description}
+                reportType={card.reportType}
+                onExport={handleExport}
+                isLoading={exportLoading === card.reportType}
+              />
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -308,4 +308,23 @@ export const createReview = async (reviewData: Omit<Review, 'id' | 'created_at'>
     return data;
 };
 
+export const getMonthlyRevenueSummary = async (numMonths: number = 6): Promise<{ month_start: string; total_revenue: number }[]> => {
+    const { data, error } = await supabase.rpc('get_monthly_revenue_summary', { num_months: numMonths });
+    if (error) {
+        console.error("Error fetching monthly revenue summary:", error);
+        throw error;
+    }
+    return data;
+};
+
+export const getFullExportData = async (reportType: 'financial' | 'users' | 'products' | 'organization_profile'): Promise<any> => {
+    const { data, error } = await supabase.rpc('get_full_export_data', { report_type: reportType });
+    if (error) {
+        console.error(`Error fetching export data for ${reportType}:`, error);
+        throw error;
+    }
+    return data;
+};
+
+
 export type { ProductFormData };


### PR DESCRIPTION
…xport)

This commit introduces a new "Reports" section to the admin dashboard, providing comprehensive data analysis and export capabilities.

- Implemented a new API route `/api/admin/export` for generating Excel reports (financial, users, products, organization profile).
- Added a dedicated `ReportsTab` component for the admin UI, featuring a monthly revenue summary chart.
- Integrated export buttons for various report types with client-side download functionality.
- Introduced new Supabase RPC functions (`get_monthly_revenue_summary` and `get_full_export_data`) for secure data retrieval.
- Updated `AdminSidebar` to include the new 'Laporan' (Reports) tab.
- Added `xlsx` and `recharts` to project dependencies.